### PR TITLE
allow http permanently

### DIFF
--- a/sacloud-drupal-statup.sh
+++ b/sacloud-drupal-statup.sh
@@ -160,7 +160,7 @@ systemctl enable httpd.service || exit 1
 systemctl start httpd.service || exit 1
 
 # ファイアウォールに対し http プロトコルでのアクセスを許可する
-firewall-cmd --add-service=http || exit 1
+firewall-cmd --permanent --add-service=http || exit 1
 
 # レポート画面で利用可能なアップデートに問題があると警告されるため、アップデート
 # 処理を行う。


### PR DESCRIPTION
firewall-cmdにpermanentオプションが付いていないので、再起動するとhttpのアクセスが許可されない (実はデフォルトで許可されている？)。
