### PR TITLE
composer経由でdrushを取得するように修正

### DIFF
--- a/sacloud-drupal-statup.sh
+++ b/sacloud-drupal-statup.sh
@@ -46,9 +46,9 @@ echo "postfix postfix/main_mailer_type string 'Internet Site'" | debconf-set-sel
 # 必要なミドルウェアを全てインストール
 apt-get update || exit 1
 if [ $DISTRIB_RELEASE = "14.04" ]; then
-  required_packages="apache2 mysql-server php5 php5-apcu php5-mysql php5-gd mailutils"
+  required_packages="apache2 mysql-server php5 php5-apcu php5-mysql php5-gd mailutils composer zip unzip"
 elif [ $DISTRIB_RELEASE = "16.04" ]; then
-  required_packages="apache2 libapache2-mod-php mysql-server php php-apcu php-mysql php-gd php-xml mailutils"
+  required_packages="apache2 libapache2-mod-php mysql-server php php-apcu php-mysql php-gd php-xml mailutils composer zip unzip"
 fi
 apt-get -y install $required_packages
 
@@ -106,13 +106,11 @@ fi
 
 service apache2 restart
 
-# 最新版の Drush をダウンロードする
-php -r "readfile('http://files.drush.org/drush.phar');" > drush || exit 1
-
-# drush コマンドを実行可能にして /usr/local/bin に移動
-chmod +x drush || exit 1
-mv drush /usr/local/bin || exit 1
-drush=/usr/local/bin/drush
+# 8.xの Drush をダウンロードする
+mkdir /opt/composer && cd $_
+COMPOSER_HOME="/opt/composer" composer config -g repositories.packagist composer https://packagist.org
+COMPOSER_HOME="/opt/composer" composer require "drush/drush":"~8"
+drush="$(pwd)/vendor/bin/drush"
 
 # Drupal をダウンロード
 if [ $DRUPAL_VERSION -eq 7 ]; then


### PR DESCRIPTION
Ubuntu版でもcomposer経由でdrushを取得するように変更し、スタートアップスクリプトが正しく機能するように変更しました。